### PR TITLE
Problem: latest tendermint-* 0.20 not used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,17 @@
-*Unreleased*
+*June 25, 2021*
 
 Dependency upgrades, logging and backup/recovery improvements.
 ## v0.2.0
 ### Breaking changes
 * [68](https://github.com/crypto-com/tmkms-light/pull/68) production logging in NE
+* [87](https://github.com/crypto-com/tmkms-light/pull/87) keygen in NE
+* [95](https://github.com/crypto-com/tmkms-light/pull/95) attestation for keygen in NE
+* [94](https://github.com/crypto-com/tmkms-light/pull/94) logging level configurable in enclaves and hosts
 * [55](https://github.com/crypto-com/tmkms-light/pull/55) SGX init and recovery commands paramater change
 * [80](https://github.com/crypto-com/tmkms-light/pull/80) SGX backup and recovery in cloud environments
+
+### Improvements
+* [89](https://github.com/crypto-com/tmkms-light/pull/89) Instance Metadata Service Version 2 used in the NE host
 
 *March 18, 2021*
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,15 +19,6 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "aead"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fc95d1bdb8e6666b2b217308eeeb09f2d6728d104be3e31916cc74d15420331"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
-name = "aead"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "922b33332f54fc0ad13fa3e514601e8d30fb54e1f3eadc36643f6526db645621"
@@ -42,7 +33,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "495ee669413bfbe9e8cace80f4d3d78e6d8c8d99579f97fb93bde351b185f2d4"
 dependencies = [
  "cfg-if 1.0.0",
- "cipher 0.3.0",
+ "cipher",
  "cpufeatures",
  "opaque-debug",
 ]
@@ -53,9 +44,9 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfde8146762f3c5f3c5cd41aa17a71f3188df09d5857192b658510d850e16068"
 dependencies = [
- "aead 0.4.1",
+ "aead",
  "aes",
- "cipher 0.3.0",
+ "cipher",
  "ctr",
  "polyval",
  "subtle",
@@ -263,23 +254,25 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chacha20"
-version = "0.6.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed8738f14471a99f0e316c327e68fc82a3611cc2895fcb604b89eedaf8f39d95"
+checksum = "fee7ad89dc1128635074c268ee661f90c3f7e83d9fd12910608c36b47d6c3412"
 dependencies = [
- "cipher 0.2.5",
+ "cfg-if 1.0.0",
+ "cipher",
+ "cpufeatures",
  "zeroize",
 ]
 
 [[package]]
 name = "chacha20poly1305"
-version = "0.7.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af1fc18e6d90c40164bf6c317476f2a98f04661e310e79830366b7e914c58a8e"
+checksum = "1580317203210c517b6d44794abfbe600698276db18127e37ad3e69bf5e848e5"
 dependencies = [
- "aead 0.3.2",
+ "aead",
  "chacha20",
- "cipher 0.2.5",
+ "cipher",
  "poly1305",
  "zeroize",
 ]
@@ -296,15 +289,6 @@ dependencies = [
  "serde",
  "time",
  "winapi 0.3.9",
-]
-
-[[package]]
-name = "cipher"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12f8e7987cbd042a63249497f41aed09f8e65add917ea6566effbc56578d6801"
-dependencies = [
- "generic-array",
 ]
 
 [[package]]
@@ -355,12 +339,6 @@ checksum = "ed00c67cb5d0a7d64a44f6ad2668db7e7530311dd53ea79bcd4fb022c64911c8"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "cpuid-bool"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb25d077389e53838a8158c8e99174c5a9d902dee4904320db714f3c653ffba"
 
 [[package]]
 name = "crossbeam"
@@ -500,7 +478,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a232f92a03f37dd7d7dd2adc67166c77e9cd88de5b019b9a9eecfaeaf7bfd481"
 dependencies = [
- "cipher 0.3.0",
+ "cipher",
 ]
 
 [[package]]
@@ -663,6 +641,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "flume"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddad16e8529759736a9ce4cdf078ed702e45d3c5b0474a1c65f5149e9fa7f1eb"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "nanorand",
+ "pin-project",
+ "spinning_top",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -714,12 +705,6 @@ name = "fuchsia-zircon-sys"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
-
-[[package]]
-name = "funty"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
 
 [[package]]
 name = "futures"
@@ -851,8 +836,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
 dependencies = [
  "cfg-if 1.0.0",
+ "js-sys",
  "libc",
  "wasi 0.10.2+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1121,6 +1108,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a"
 
 [[package]]
+name = "lock_api"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0382880606dff6d15c9476c416d18690b72742aa7b605bb6dd6ec9030fbf07eb"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1276,6 +1272,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
 dependencies = [
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "nanorand"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac1378b66f7c93a1c0f8464a19bf47df8795083842e5090f4b7305973d5a22d0"
+dependencies = [
+ "getrandom 0.2.3",
 ]
 
 [[package]]
@@ -1557,6 +1562,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
+name = "pin-project"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7509cc106041c40a4518d2af7a61530e1eed0e6285296a3d8c5472806ccc4a4"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c950132583b500556b1efd71d45b319029f2b71518d979fcc208e16b42426f"
+dependencies = [
+ "proc-macro2 1.0.27",
+ "quote 1.0.9",
+ "syn 1.0.72",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1582,11 +1607,12 @@ checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
 
 [[package]]
 name = "poly1305"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b7456bc1ad2d4cf82b3a016be4c2ac48daf11bf990c1603ebd447fe6f30fca8"
+checksum = "4fe800695325da85083cd23b56826fccb2e2dc29b218e7811a6f33bc93f414be"
 dependencies = [
- "cpuid-bool",
+ "cpufeatures",
+ "opaque-debug",
  "universal-hash",
 ]
 
@@ -2201,6 +2227,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
+name = "spinning_top"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75adad84ee84b521fb2cca2d4fd0f1dab1d8d026bda3c5bea4ca63b5f9f9293c"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
 name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2311,9 +2346,9 @@ dependencies = [
 
 [[package]]
 name = "tendermint"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "831486f28e65c6f6c6f8afb067796f3c470db91a44d177224f8e6287601391b6"
+checksum = "e7d330f5d92e5e1c7a84130805b48b4983d98a37257034544492e3566315142b"
 dependencies = [
  "anomaly",
  "async-trait",
@@ -2321,7 +2356,6 @@ dependencies = [
  "chrono",
  "ed25519",
  "ed25519-dalek",
- "funty",
  "futures 0.3.15",
  "num-traits",
  "once_cell",
@@ -2344,20 +2378,20 @@ dependencies = [
 
 [[package]]
 name = "tendermint-p2p"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e18eefbf8ac2326c3d5260bcbb5b3fe0c78b3f6a091c936fb2991aac258d420e"
+checksum = "f3f053bedf8b28f30e4ad307848bd546557c43e5191f7d4cd3e3b6d754254530"
 dependencies = [
  "chacha20poly1305",
  "ed25519-dalek",
  "eyre",
+ "flume",
  "hkdf",
  "merlin",
  "prost",
  "rand_core 0.5.1",
  "sha2",
  "subtle",
- "subtle-encoding",
  "tendermint",
  "tendermint-proto",
  "thiserror",
@@ -2367,9 +2401,9 @@ dependencies = [
 
 [[package]]
 name = "tendermint-proto"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32bbc1bc55f09de4d00b5d69aa6b60392ba37c5e4761d869f76065d352bd3360"
+checksum = "fadcaea1eecd91dbdd9636fe8ad38d2b41fc0ae814c176e51e00925cdda78a34"
 dependencies = [
  "anomaly",
  "bytes 1.0.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,9 @@ ed25519-dalek = "1"
 prost = "0.7"
 serde = { version = "1", features = ["serde_derive"] }
 subtle-encoding = { version = "0.5", features = ["bech32-preview"] }
-tendermint = { version = "0.19" }
-tendermint-proto = "0.19"
-tendermint-p2p = { version = "0.19" }
+tendermint = { version = "0.20" }
+tendermint-proto = "0.20"
+tendermint-p2p = { version = "0.20" }
 thiserror = "1"
 tracing = "0.1"
 

--- a/providers/nitro/nitro-enclave/Cargo.toml
+++ b/providers/nitro/nitro-enclave/Cargo.toml
@@ -16,8 +16,8 @@ serde_bytes = "0.11"
 serde_json = "1"
 subtle = "2"
 subtle-encoding = "0.5"
-tendermint = { version = "0.19" }
-tendermint-p2p = { version = "0.19" }
+tendermint = { version = "0.20" }
+tendermint-p2p = { version = "0.20" }
 tmkms-light = { path = "../../.." }
 tmkms-nitro-helper = { path = "../nitro-helper", default-features = false }
 tracing = "0.1"

--- a/providers/nitro/nitro-helper/Cargo.toml
+++ b/providers/nitro/nitro-helper/Cargo.toml
@@ -24,7 +24,7 @@ structopt = "0.3"
 subtle-encoding = { version = "0.5", features = [ "bech32-preview" ] }
 sysinfo = { version = "0.18", optional = true }
 tempfile = "3"
-tendermint = { version = "0.19" }
+tendermint = { version = "0.20" }
 thiserror = "1"
 tmkms-light = { path = "../../.." }
 tokio = { version = "1", features = [ "rt" ] }

--- a/providers/sgx/sgx-app/Cargo.toml
+++ b/providers/sgx/sgx-app/Cargo.toml
@@ -17,7 +17,7 @@ sha2 = "0.9"
 sgx-isa = { version = "0.3", features = ["sgxstd"] }
 subtle = "2"
 subtle-encoding = "0.5"
-tendermint-p2p = "0.19"
+tendermint-p2p = "0.20"
 tmkms-light-sgx-runner = { path = "../sgx-runner" }
 tmkms-light = { path = "../../.." }
 tracing = "0.1"

--- a/providers/sgx/sgx-runner/Cargo.toml
+++ b/providers/sgx/sgx-runner/Cargo.toml
@@ -12,7 +12,7 @@ ed25519-dalek = "1"
 rsa = { version = "0.4", features = ["serde"] }
 sgx-isa = { version = "0.3", features = ["serde"] }
 thiserror = "1"
-tendermint = { version = "0.19" }
+tendermint = { version = "0.20" }
 tmkms-light = { path = "../../.." }
 zeroize = "1"
 

--- a/providers/softsign/Cargo.toml
+++ b/providers/softsign/Cargo.toml
@@ -16,8 +16,8 @@ structopt = "0.3"
 subtle = "2"
 subtle-encoding = { version = "0.5", features = ["bech32-preview"] }
 tempfile = "3"
-tendermint = { version = "0.19" }
-tendermint-p2p = { version = "0.19" }
+tendermint = { version = "0.20" }
+tendermint-p2p = { version = "0.20" }
 tmkms-light = { path = "../.." }
 tracing = "0.1"
 tracing-subscriber = "0.2"

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -165,7 +165,7 @@ impl Response {
             Response::PublicKey(pk) => {
                 let pkr = PubKeyResponse {
                     pub_key: Some(RawPublicKey {
-                        sum: Some(PkSum::Ed25519(pk.to_vec())),
+                        sum: Some(PkSum::Ed25519(pk.to_bytes())),
                     }),
                     error: None,
                 };


### PR DESCRIPTION
Solution: upgraded all crates at once, a small API fix
and updated the changelog
