### PR TITLE
Problem: Nitro build fails with upgrade of zeroize 1.4.0(#129)

### DIFF
--- a/.github/workflows/tmkms.yml
+++ b/.github/workflows/tmkms.yml
@@ -121,7 +121,7 @@ jobs:
           push: false
           file: Dockerfile.nitro
           build-args: |
-            RUST_TOOLCHAIN=1.50.0
+            RUST_TOOLCHAIN=1.52.1
   run-integration-tests:
     runs-on: ubuntu-latest
     needs: build


### PR DESCRIPTION
zeroize 1.4.1 requires Rust 1.51 or newer.