### PR TITLE
Problem: upgrade to tendermint-* 0.22.0 fails (fixes #178)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -687,6 +687,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "flex-error"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e8de6bf49fb8856ee814e288a518e0d45598b6f78a95c1233b96eedba8bc06a"
+dependencies = [
+ "eyre",
+ "paste",
+]
+
+[[package]]
 name = "flume"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1580,6 +1590,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf547ad0c65e31259204bd90935776d1c693cec2f4ff7abb7a1bbbd40dfe58"
+
+[[package]]
 name = "pem-rfc7468"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2399,16 +2415,16 @@ dependencies = [
 
 [[package]]
 name = "tendermint"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0752808f59b612916614e92e43be64e9ba566b762a266bcfcf7dce1b324e9319"
+checksum = "fa5354dfcc3bbd8bf3b000b9cfb19afcb4e1bbaed9d6b2d6bc2fa05e027bd7e1"
 dependencies = [
- "anomaly",
  "async-trait",
  "bytes 1.0.1",
  "chrono",
  "ed25519",
  "ed25519-dalek",
+ "flex-error",
  "futures 0.3.16",
  "num-traits",
  "once_cell",
@@ -2423,7 +2439,7 @@ dependencies = [
  "subtle",
  "subtle-encoding",
  "tendermint-proto",
- "thiserror",
+ "time",
  "toml",
  "url",
  "zeroize",
@@ -2431,36 +2447,39 @@ dependencies = [
 
 [[package]]
 name = "tendermint-p2p"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17f4ca60f48da1a7a942f99ac09fbfb9b0a0484eedbf597d8781aa7fffd3bca2"
+checksum = "2556ced9c4daabb5825ece78dd314c9a0d58c86bf91a72160ef6536630a1bb6f"
 dependencies = [
+ "aead",
  "chacha20poly1305",
  "ed25519-dalek",
  "eyre",
+ "flex-error",
  "flume",
  "hkdf",
  "merlin",
  "prost",
  "rand_core 0.5.1",
  "sha2",
+ "signature",
  "subtle",
  "tendermint",
  "tendermint-proto",
- "thiserror",
+ "tendermint-std-ext",
  "x25519-dalek",
  "zeroize",
 ]
 
 [[package]]
 name = "tendermint-proto"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfd0371c6b0c7fc4f6b053b8a1bc868a2a47c49a1408c4cd6f595d9f3bd3c238"
+checksum = "4c36f58bd68be7a6e3221c49cc1a14cbc619c189bb26a43425f544831922d2be"
 dependencies = [
- "anomaly",
  "bytes 1.0.1",
  "chrono",
+ "flex-error",
  "num-derive 0.3.3",
  "num-traits",
  "prost",
@@ -2468,8 +2487,13 @@ dependencies = [
  "serde",
  "serde_bytes",
  "subtle-encoding",
- "thiserror",
 ]
+
+[[package]]
+name = "tendermint-std-ext"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21dba479415a6ad8892982a375fbc98f1939122460e8a6f07f0db4ec303965d0"
 
 [[package]]
 name = "textwrap"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,9 @@ ed25519-dalek = "1"
 prost = "0.7"
 serde = { version = "1", features = ["serde_derive"] }
 subtle-encoding = { version = "0.5", features = ["bech32-preview"] }
-tendermint = { version = "0.21" }
-tendermint-proto = "0.21"
-tendermint-p2p = { version = "0.21" }
+tendermint = { version = "0.22" }
+tendermint-proto = "0.22"
+tendermint-p2p = { version = "0.22" }
 thiserror = "1"
 tracing = "0.1"
 

--- a/providers/nitro/nitro-enclave/Cargo.toml
+++ b/providers/nitro/nitro-enclave/Cargo.toml
@@ -16,8 +16,8 @@ serde_bytes = "0.11"
 serde_json = "1"
 subtle = "2"
 subtle-encoding = "0.5"
-tendermint = { version = "0.21" }
-tendermint-p2p = { version = "0.21" }
+tendermint = { version = "0.22" }
+tendermint-p2p = { version = "0.22" }
 tmkms-light = { path = "../../.." }
 tmkms-nitro-helper = { path = "../nitro-helper", default-features = false }
 tracing = "0.1"

--- a/providers/nitro/nitro-helper/Cargo.toml
+++ b/providers/nitro/nitro-helper/Cargo.toml
@@ -25,7 +25,7 @@ structopt = "0.3"
 subtle-encoding = { version = "0.5", features = [ "bech32-preview" ] }
 sysinfo = { version = "0.20", optional = true }
 tempfile = "3"
-tendermint = { version = "0.21" }
+tendermint = { version = "0.22" }
 thiserror = "1"
 tmkms-light = { path = "../../.." }
 tokio = { version = "1", features = [ "rt" ] }

--- a/providers/sgx/sgx-app/Cargo.toml
+++ b/providers/sgx/sgx-app/Cargo.toml
@@ -17,7 +17,7 @@ sha2 = "0.9"
 sgx-isa = { version = "0.3", features = ["sgxstd"] }
 subtle = "2"
 subtle-encoding = "0.5"
-tendermint-p2p = "0.21"
+tendermint-p2p = "0.22"
 tmkms-light-sgx-runner = { path = "../sgx-runner" }
 tmkms-light = { path = "../../.." }
 tracing = "0.1"

--- a/providers/sgx/sgx-runner/Cargo.toml
+++ b/providers/sgx/sgx-runner/Cargo.toml
@@ -12,7 +12,7 @@ ed25519-dalek = "1"
 rsa = { version = "0.5", features = ["serde", "alloc"] }
 sgx-isa = { version = "0.3", features = ["serde"] }
 thiserror = "1"
-tendermint = { version = "0.21" }
+tendermint = { version = "0.22" }
 tmkms-light = { path = "../../.." }
 zeroize = "1"
 

--- a/providers/softsign/Cargo.toml
+++ b/providers/softsign/Cargo.toml
@@ -16,8 +16,8 @@ structopt = "0.3"
 subtle = "2"
 subtle-encoding = { version = "0.5", features = ["bech32-preview"] }
 tempfile = "3"
-tendermint = { version = "0.21" }
-tendermint-p2p = { version = "0.21" }
+tendermint = { version = "0.22" }
+tendermint-p2p = { version = "0.22" }
 tmkms-light = { path = "../.." }
 tracing = "0.1"
 tracing-subscriber = "0.2"

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -109,7 +109,7 @@ impl Response {
     /// signed vote
     pub fn vote_response(vote: SignVoteRequest, signature: ed25519_dalek::Signature) -> Self {
         let mut vote = vote.vote;
-        vote.signature = signature.into();
+        vote.signature = Some(signature.into());
         Response::SignedVote(SignedVoteResponse {
             vote: Some(vote),
             error: None,
@@ -122,7 +122,7 @@ impl Response {
         signature: ed25519_dalek::Signature,
     ) -> Self {
         let mut proposal = proposal.proposal;
-        proposal.signature = signature.into();
+        proposal.signature = Some(signature.into());
         Response::SignedProposal(SignedProposalResponse {
             proposal: Some(proposal),
             error: None,


### PR DESCRIPTION
Solution: bump all tendermint-rs crates together + small struct change
