### PR TITLE
Problem: tendermint-p2p upgrade to 0.23.8 fails to build on nitro (fixes #366)

### DIFF
--- a/.github/workflows/tmkms.yml
+++ b/.github/workflows/tmkms.yml
@@ -131,7 +131,7 @@ jobs:
           push: false
           file: Dockerfile.nitro
           build-args: |
-            RUST_TOOLCHAIN=1.56.1
+            RUST_TOOLCHAIN=1.62.1
   run-integration-tests:
     runs-on: ubuntu-latest
     needs: build

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2699,9 +2699,9 @@ dependencies = [
 
 [[package]]
 name = "tendermint-p2p"
-version = "0.23.7"
+version = "0.23.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bbbba11b8b261ec9aaccd546dd31f0e9433838eeac753846a9f3627c39cc35c"
+checksum = "87c1c10e044ce8c86a21837bdf2efc7bcce1436c7a1cc468bca910b5c266be46"
 dependencies = [
  "aead",
  "chacha20poly1305",
@@ -2743,9 +2743,9 @@ dependencies = [
 
 [[package]]
 name = "tendermint-std-ext"
-version = "0.23.7"
+version = "0.23.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56664cdac0c2deb171ece5db6fd5427eda13da1d4df609d246e360dd2e0af3d8"
+checksum = "23430464d228dbbe10da041b1ebaf49b8d752bf5c54dfb3d166a9dc660eedfaa"
 
 [[package]]
 name = "textwrap"

--- a/Dockerfile.nitro
+++ b/Dockerfile.nitro
@@ -1,7 +1,8 @@
 # This dockerfile is taken from https://github.com/aws/aws-nitro-enclaves-acm/blob/main/env/enclave/Dockerfile
 # Modified to help build tmkms-nitro-enclave eif
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2020-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Modifications Copyright (c) 2021-present Crypto.com (licensed under the Apache License, Version 2.0)
 # SPDX-License-Identifier: Apache-2.0
 
 # This Docker file sets up the development environment for the eVault components
@@ -34,16 +35,13 @@ RUN apk add \
     shadow \
     sudo
 
-# Only needed to build aws-lc
-RUN apk add quilt --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing
-
 RUN ln -s /usr/lib /usr/lib64
 
 RUN mkdir -p /build
 WORKDIR /build
 
 # Build AWS libcrypto
-ENV AWS_LC_VER="v0.0.2"
+ENV AWS_LC_VER="v1.0.2"
 RUN git clone "https://github.com/awslabs/aws-lc.git" \
     && cd aws-lc \
     && git reset --hard $AWS_LC_VER \
@@ -59,7 +57,7 @@ RUN git clone "https://github.com/awslabs/aws-lc.git" \
     && ldconfig /usr/lib
 
 # AWS-S2N
-ENV AWS_S2N_VER="v1.1.1"
+ENV AWS_S2N_VER="v1.3.11"
 RUN git clone https://github.com/aws/s2n-tls.git \
     && cd s2n-tls \
     && git reset --hard $AWS_S2N_VER \
@@ -72,7 +70,7 @@ RUN git clone https://github.com/aws/s2n-tls.git \
     && cmake --build build/ --parallel $(nproc) --target install
 
 # AWS-C-COMMON
-ENV AWS_C_COMMON_VER="v0.6.11"
+ENV AWS_C_COMMON_VER="v0.6.20"
 RUN git clone https://github.com/awslabs/aws-c-common.git \
     && cd aws-c-common \
     && git reset --hard $AWS_C_COMMON_VER \
@@ -84,8 +82,21 @@ RUN git clone https://github.com/awslabs/aws-c-common.git \
         -B build \
     && cmake --build build/ --parallel $(nproc) --target install
 
+# AWS-C-SDKUTILS
+ENV AWS_C_SDKUTILS_VER="v0.1.2"
+RUN git clone https://github.com/awslabs/aws-c-sdkutils \
+    && cd aws-c-sdkutils \
+    && git reset --hard $AWS_C_SDKUTILS_VER \
+    && cmake \
+        -DCMAKE_PREFIX_PATH=/usr \
+        -DCMAKE_INSTALL_PREFIX=/usr \
+        -DBUILD_SHARED_LIBS=1 \
+        -DBUILD_TESTING=0 \
+        -B build \
+    && cmake --build build/ --parallel $(nproc) --target install
+
 # AWS-C-CAL
-ENV AWS_C_CAL_VER="v0.5.12"
+ENV AWS_C_CAL_VER="v0.5.17"
 RUN git clone https://github.com/awslabs/aws-c-cal.git \
     && cd aws-c-cal \
     && git reset --hard $AWS_C_CAL_VER \
@@ -98,7 +109,7 @@ RUN git clone https://github.com/awslabs/aws-c-cal.git \
     && cmake --build build --parallel $(nproc) --target install
 
 # AWS-C-IO
-ENV AWS_C_IO_VER="v0.10.9"
+ENV AWS_C_IO_VER="v0.10.21"
 RUN git clone https://github.com/awslabs/aws-c-io.git \
     && cd aws-c-io \
     && git reset --hard $AWS_C_IO_VER \
@@ -125,7 +136,7 @@ RUN git clone http://github.com/awslabs/aws-c-compression.git \
     && cmake --build build --parallel $(nproc) --target install
 
 # AWS-C-HTTP
-ENV AWS_C_HTTP_VER="v0.6.7"
+ENV AWS_C_HTTP_VER="v0.6.13"
 RUN git clone https://github.com/awslabs/aws-c-http.git \
     && cd aws-c-http \
     && git reset --hard $AWS_C_HTTP_VER \
@@ -138,7 +149,7 @@ RUN git clone https://github.com/awslabs/aws-c-http.git \
     && cmake --build build --parallel $(nproc) --target install
 
 # AWS-C-AUTH
-ENV AWS_C_AUTH_VER="v0.6.4"
+ENV AWS_C_AUTH_VER="v0.6.11"
 RUN git clone https://github.com/awslabs/aws-c-auth.git \
     && cd aws-c-auth \
     && git reset --hard $AWS_C_AUTH_VER \
@@ -151,7 +162,7 @@ RUN git clone https://github.com/awslabs/aws-c-auth.git \
     && cmake --build build --parallel $(nproc) --target install
 
 # JSON-C library
-ENV JSON_C_VER="json-c-0.15-20200726"
+ENV JSON_C_VER="json-c-0.16-20220414"
 RUN git clone https://github.com/json-c/json-c.git \
     && cd json-c \
     && git reset --hard $JSON_C_VER \
@@ -167,16 +178,16 @@ RUN git clone https://github.com/json-c/json-c.git \
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain $RUST_TOOLCHAIN
 
 # NSM LIB
-ENV AWS_NE_NSM_API_VER="34bad95f97f8c83a844e1db8695e91552b1aa9f3"
+ENV AWS_NE_NSM_API_VER="v0.2.1"
 RUN git clone "https://github.com/aws/aws-nitro-enclaves-nsm-api" \
     && cd aws-nitro-enclaves-nsm-api \
     && git reset --hard $AWS_NE_NSM_API_VER \
-    && PATH="$PATH:/root/.cargo/bin" cargo build --release \
+    && PATH="$PATH:/root/.cargo/bin" cargo build --release -p nsm-lib \
     && mv target/release/libnsm.so /usr/lib/ \
     && mv target/release/nsm.h /usr/include/
 
 # AWS Nitro Enclaves SDK
-ENV AWS_NE_SDK_VER="v0.2.0"
+ENV AWS_NE_SDK_VER="v0.2.1"
 RUN git clone "https://github.com/aws/aws-nitro-enclaves-sdk-c" \
     && cd aws-nitro-enclaves-sdk-c \
     && git reset --hard $AWS_NE_SDK_VER \


### PR DESCRIPTION
Solution:
- bumped crates
- updated the toolchain
- updated dockerfile dependencies as per the upstream one: https://github.com/aws/aws-nitro-enclaves-acm/blob/main/env/enclave/Dockerfile
