### PR TITLE
Problem: upgrading aws-* crates to 0.46 fails (fixes #367)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -156,9 +156,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "aws-config"
-version = "0.15.0"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a8c0628604c0a0afcd417548f085fd52e4ad54cacbf96437db4f45a27a47636"
+checksum = "11a8c971b0cb0484fc9436a291a44503b95141edc36ce7a6af6b6d7a06a02ab0"
 dependencies = [
  "aws-http",
  "aws-sdk-sso",
@@ -183,9 +183,9 @@ dependencies = [
 
 [[package]]
 name = "aws-endpoint"
-version = "0.15.0"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bae67aca7c551d061a06606ad445d717ee28ac08f70d0f2358096c70118bdfe"
+checksum = "4bc956f415dda77215372e5bc751a2463d1f9a1ec34edf3edc6c0ff67e5c8e43"
 dependencies = [
  "aws-smithy-http",
  "aws-types",
@@ -196,16 +196,19 @@ dependencies = [
 
 [[package]]
 name = "aws-http"
-version = "0.15.0"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2145230145123a3308c09a9f8aac2e2213c5540dd0e3a77200c32b20575cbcb"
+checksum = "3a0d98a1d606aa24554e604f220878db4aa3b525b72f88798524497cc3867fc6"
 dependencies = [
  "aws-smithy-http",
  "aws-smithy-types",
  "aws-types",
+ "bytes 1.1.0",
  "http",
+ "http-body",
  "lazy_static",
  "percent-encoding",
+ "pin-project-lite 0.2.9",
  "tracing",
 ]
 
@@ -231,9 +234,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d3df9fc9d07b0d1dc897a5e9aee924fd8527ff3d8a15677ca4dbb14969aacf0"
+checksum = "baa0c66fab12976065403cf4cafacffe76afa91d0da335d195af379d4223d235"
 dependencies = [
  "aws-endpoint",
  "aws-http",
@@ -253,9 +256,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479f057a876f04ae8594d6f6633572ce7946fda5f1ae420cdfde653d61841bbe"
+checksum = "048037cdfd7f42fb29b5f969c7f639b4b7eac00e8f911e4eac4f89fb7b3a0500"
 dependencies = [
  "aws-endpoint",
  "aws-http",
@@ -275,9 +278,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sig-auth"
-version = "0.15.0"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffea94eb16f7f14153d4ff086aa075e0725050ee89ac6c1538cc1b229c64b420"
+checksum = "e8386fc0d218dbf2011f65bd8300d21ba98603fd150b962f61239be8b02d1fc6"
 dependencies = [
  "aws-sigv4",
  "aws-smithy-http",
@@ -288,9 +291,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sigv4"
-version = "0.15.0"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "543ad4870152e9850fcbbaec1e1c746c4905682053866848af99681227198cab"
+checksum = "cd866926c2c4978210bcb01d7d1b431c794f0c23ca9ee1e420204b018836b5fb"
 dependencies = [
  "aws-smithy-http",
  "form_urlencoded",
@@ -306,9 +309,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-async"
-version = "0.45.0"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5a05f0f76616a4495999f4132287b4a0ebbb4e733aedbae0e120294f336faf1"
+checksum = "deb59cfdd21143006c01b9ca4dc4a9190b8c50c2ef831f9eb36f54f69efa42f1"
 dependencies = [
  "futures-util",
  "pin-project-lite 0.2.9",
@@ -318,9 +321,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-client"
-version = "0.45.0"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7a1f41d103bc313190a2af4bb8ff67311ae2e673e3701202fe707fc9597da4c"
+checksum = "44243329ba8618474c3b7f396de281f175ae172dd515b3d35648671a3cf51871"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
@@ -341,9 +344,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http"
-version = "0.45.0"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17bf583ba80ee4ef0fbae4fd1bce07567a03411ac2f82f80d2cfb41ea263c172"
+checksum = "fba78f69a5bbe7ac1826389304c67b789032d813574e78f9a2d450634277f833"
 dependencies = [
  "aws-smithy-types",
  "bytes 1.1.0",
@@ -360,9 +363,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-tower"
-version = "0.45.0"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8845020b3875bcaf61c4174430975a07dc9ca9653f1029fcbbf61d197cbe593"
+checksum = "ff8a512d68350561e901626baa08af9491cfbd54596201b84b4da846a59e4da3"
 dependencies = [
  "aws-smithy-http",
  "bytes 1.1.0",
@@ -375,18 +378,18 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-json"
-version = "0.45.0"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "748702917f9c54f8300710cb7284152fdba6881741654880bfd5c11ecf230425"
+checksum = "31b7633698853aae80bd8b26866531420138eca91ea4620735d20b0537c93c2e"
 dependencies = [
  "aws-smithy-types",
 ]
 
 [[package]]
 name = "aws-smithy-query"
-version = "0.45.0"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ca90dfe7151841de25e9e0d1862605aec4fe63fbfdf81417d3dc4baef562350"
+checksum = "95a94b5a8cc94a85ccbff89eb7bc80dc135ede02847a73d68c04ac2a3e4cf6b7"
 dependencies = [
  "aws-smithy-types",
  "urlencoding",
@@ -394,9 +397,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "0.45.0"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83b74dbb59d20bf29d62772c99dfb8b32377a101c0b03879138f34b3e9b15bdc"
+checksum = "d230d281653de22fb0e9c7c74d18d724a39d7148e2165b1e760060064c4967c0"
 dependencies = [
  "itoa",
  "num-integer",
@@ -406,18 +409,18 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-xml"
-version = "0.45.0"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4bff2d07dd531709cd1e9153c15a859ca394c9d6b2bb8e91d16960ea1fc8ae6"
+checksum = "4aacaf6c0fa549ebe5d9daa96233b8635965721367ee7c69effc8d8078842df3"
 dependencies = [
  "xmlparser",
 ]
 
 [[package]]
 name = "aws-types"
-version = "0.15.0"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15d31c4af87ae335c41a1ce7d6d699ef274551444e920e93afca3e008aee8f89"
+checksum = "fb54f097516352475a0159c9355f8b4737c54044538a4d9aca4d376ef2361ccc"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-client",
@@ -1274,9 +1277,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ff4f84919677303da5f147645dbea6b1881f368d03ac84e1dc09031ebd7b2c6"
+checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
 dependencies = [
  "bytes 1.1.0",
  "http",
@@ -1450,9 +1453,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.121"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efaa7b300f3b5fe8eb6bf21ce3895e1751d9665086af2d64b42f19701015ff4f"
+checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
 
 [[package]]
 name = "libloading"
@@ -1666,19 +1669,6 @@ name = "nix"
 version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5e06129fb611568ef4e868c14b326274959aa70ff7776e9d55323531c374945"
-dependencies = [
- "bitflags",
- "cc",
- "cfg-if 1.0.0",
- "libc",
- "memoffset 0.6.5",
-]
-
-[[package]]
-name = "nix"
-version = "0.23.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f866317acbd3a240710c63f065ffb1e4fd466259045ccb504130b7f668f35c6"
 dependencies = [
  "bitflags",
  "cc",
@@ -2627,9 +2617,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.24.7"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54cb4ebf3d49308b99e6e9dc95e989e2fdbdc210e4f67c39db0bb89ba927001c"
+checksum = "373e4bc9213f734126e2be3e2e118dbc9b909c37487d8d755822bc90f70ae62a"
 dependencies = [
  "cfg-if 1.0.0",
  "core-foundation-sys",
@@ -3272,12 +3262,12 @@ checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "vsock"
-version = "0.2.6"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e32675ee2b3ce5df274c0ab52d19b28789632406277ca26bffee79a8e27dc133"
+checksum = "4c8e1df0bf1e1b28095c24564d1b90acae64ca69b097ed73896e342fa6649c57"
 dependencies = [
  "libc",
- "nix 0.23.1",
+ "nix 0.24.2",
 ]
 
 [[package]]

--- a/providers/nitro/nitro-enclave/Cargo.toml
+++ b/providers/nitro/nitro-enclave/Cargo.toml
@@ -21,5 +21,5 @@ tmkms-light = { path = "../../.." }
 tmkms-nitro-helper = { path = "../nitro-helper", default-features = false }
 tracing = "0.1"
 tracing-subscriber = "0.3"
-vsock = "0.2"
+vsock = "0.3"
 zeroize = "1"

--- a/providers/nitro/nitro-enclave/src/main.rs
+++ b/providers/nitro/nitro-enclave/src/main.rs
@@ -2,7 +2,7 @@ use tracing::Level;
 use tracing::{error, info, warn};
 use tracing_subscriber::fmt;
 use tracing_subscriber::layer::SubscriberExt;
-use vsock::{SockAddr, VsockListener};
+use vsock::{VsockAddr, VsockListener};
 
 use tmkms_nitro_helper::tracing_layer::Layer;
 use tmkms_nitro_helper::VSOCK_HOST_CID;
@@ -43,7 +43,7 @@ fn main() {
     tracing::subscriber::set_global_default(layered).expect("setting default subscriber failed");
 
     const VMADDR_CID_ANY: u32 = 0xFFFFFFFF;
-    let addr = SockAddr::new_vsock(VMADDR_CID_ANY, port);
+    let addr = VsockAddr::new(VMADDR_CID_ANY, port);
     let listener = VsockListener::bind(&addr).expect("bind address");
     info!("waiting for config to be pushed on {}", addr);
     for conn in listener.incoming() {

--- a/providers/nitro/nitro-enclave/src/nitro.rs
+++ b/providers/nitro/nitro-enclave/src/nitro.rs
@@ -23,7 +23,7 @@ use tmkms_nitro_helper::{
     NitroConfig, NitroKeygenResponse, NitroRequest, NitroResponse, VSOCK_HOST_CID,
 };
 use tracing::{error, info, trace, warn};
-use vsock::{SockAddr, VsockStream};
+use vsock::{VsockAddr, VsockStream};
 use zeroize::{Zeroize, Zeroizing};
 
 fn get_secret_connection(
@@ -31,7 +31,7 @@ fn get_secret_connection(
     identity_key: &ed25519::Keypair,
     peer_id: Option<Id>,
 ) -> io::Result<Box<dyn Connection>> {
-    let addr = SockAddr::new_vsock(VSOCK_HOST_CID, vsock_port);
+    let addr = VsockAddr::new(VSOCK_HOST_CID, vsock_port);
     let socket = vsock::VsockStream::connect(&addr)?;
     info!("KMS node ID: {}", PublicKey::from(identity_key));
     // the `Clone` is not derived for Keypair
@@ -76,7 +76,7 @@ pub fn get_connection(
         let conn: io::Result<Box<dyn Connection>> = if let Some(ikp) = id_keypair {
             get_secret_connection(config.enclave_tendermint_conn, ikp, config.peer_id)
         } else {
-            let addr = SockAddr::new_vsock(VSOCK_HOST_CID, config.enclave_tendermint_conn);
+            let addr = VsockAddr::new(VSOCK_HOST_CID, config.enclave_tendermint_conn);
             if let Ok(socket) = vsock::VsockStream::connect(&addr) {
                 trace!("tendermint vsock port: {}", config.enclave_tendermint_conn);
                 trace!("tendermint peer addr: {:?}", socket.peer_addr());

--- a/providers/nitro/nitro-enclave/src/nitro/state.rs
+++ b/providers/nitro/nitro-enclave/src/nitro/state.rs
@@ -4,7 +4,7 @@ use tmkms_light::chain::state::{consensus, PersistStateSync, State, StateError};
 use tmkms_light::utils::{read_u16_payload, write_u16_payload};
 use tmkms_nitro_helper::VSOCK_HOST_CID;
 use tracing::{debug, trace};
-use vsock::{SockAddr, VsockStream};
+use vsock::{VsockAddr, VsockStream};
 
 /// as the state needs to be persisted outside of NE,
 /// this is a helper that communicates with the host to load the latest state
@@ -17,7 +17,7 @@ pub struct StateHolder {
 impl StateHolder {
     /// connects to the host via the vsock port specified in the configuration
     pub fn new(vsock_port: u32) -> io::Result<Self> {
-        let addr = SockAddr::new_vsock(VSOCK_HOST_CID, vsock_port);
+        let addr = VsockAddr::new(VSOCK_HOST_CID, vsock_port);
         let state_conn = vsock::VsockStream::connect(&addr)?;
         trace!("state vsock port: {}", vsock_port);
         trace!("state peer addr: {:?}", state_conn.peer_addr());

--- a/providers/nitro/nitro-helper/Cargo.toml
+++ b/providers/nitro/nitro-helper/Cargo.toml
@@ -5,8 +5,8 @@ authors = [ "Tomas Tauber <2410580+tomtau@users.noreply.github.com>" ]
 edition = "2021"
 
 [dependencies]
-aws-config = "0.15"
-aws-types = "0.15"
+aws-config = "0.46"
+aws-types = "0.46"
 ctrlc = "3"
 ed25519-dalek = "1"
 flex-error = "0.4"
@@ -15,7 +15,7 @@ serde = { version = "1", features = [ "derive" ] }
 serde_json = "1"
 structopt = "0.3"
 subtle-encoding = { version = "0.5", features = [ "bech32-preview" ] }
-sysinfo = "0.24"
+sysinfo = "0.25"
 tempfile = "3"
 tendermint = "0.23"
 tendermint-config = "0.23"
@@ -25,4 +25,4 @@ toml = "0.5"
 tracing = "0.1"
 tracing-subscriber = "0.3"
 tracing-core = "0.1"
-vsock = "0.2"
+vsock = "0.3"

--- a/providers/nitro/nitro-helper/src/command.rs
+++ b/providers/nitro/nitro-helper/src/command.rs
@@ -7,7 +7,7 @@ use sysinfo::{ProcessExt, SystemExt};
 use tendermint_config::net;
 use tmkms_light::utils::write_u16_payload;
 use tmkms_light::utils::{print_pubkey, PubkeyDisplay};
-use vsock::SockAddr;
+use vsock::VsockAddr;
 
 use crate::command::nitro_enclave::describe_enclave;
 use crate::config::{EnclaveConfig, EnclaveOpt, NitroSignOpt, VSockProxyOpt};
@@ -171,9 +171,9 @@ pub fn start(
         aws_region: config.aws_region.clone(),
     };
     let addr = if let Some(cid) = cid {
-        SockAddr::new_vsock(cid, config.enclave_config_port)
+        VsockAddr::new(cid, config.enclave_config_port)
     } else {
-        SockAddr::new_vsock(config.enclave_config_cid, config.enclave_config_port)
+        VsockAddr::new(config.enclave_config_cid, config.enclave_config_port)
     };
     let mut socket = vsock::VsockStream::connect(&addr).map_err(|e| {
         format!(

--- a/providers/nitro/nitro-helper/src/enclave_log_server.rs
+++ b/providers/nitro/nitro-helper/src/enclave_log_server.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 use tmkms_nitro_helper::tracing_layer::Log;
 use tracing::Level;
 use tracing::{debug, error, info, trace, warn};
-use vsock::{SockAddr, VsockListener};
+use vsock::{VsockAddr, VsockListener};
 
 /// Configuration parameters for port listening and remote destination
 pub struct LogServer {
@@ -28,7 +28,7 @@ impl LogServer {
             "binding enclave log server to vsock port: {}",
             self.local_port
         );
-        let sockaddr = SockAddr::new_vsock(self.cid, self.local_port);
+        let sockaddr = VsockAddr::new(self.cid, self.local_port);
         let listener = VsockListener::bind(&sockaddr)
             .map_err(|e| format!("Could not bind to {:?}, {:?}", sockaddr, e))?;
         info!("Bound enclave log server to {:?}", sockaddr);

--- a/providers/nitro/nitro-helper/src/key_utils.rs
+++ b/providers/nitro/nitro-helper/src/key_utils.rs
@@ -4,7 +4,7 @@ use crate::shared::{NitroKeygenConfig, NitroKeygenResponse, NitroRequest, NitroR
 use ed25519_dalek::PublicKey;
 use std::{fs::OpenOptions, io::Write, os::unix::fs::OpenOptionsExt, path::Path};
 use tmkms_light::utils::{read_u16_payload, write_u16_payload};
-use vsock::SockAddr;
+use vsock::VsockAddr;
 
 pub(crate) mod credential {
     use crate::shared::AwsCredentials;
@@ -51,7 +51,7 @@ pub fn generate_key(
     };
 
     let request = NitroRequest::Keygen(keygen_request);
-    let addr = SockAddr::new_vsock(cid, port);
+    let addr = VsockAddr::new(cid, port);
     let mut socket = vsock::VsockStream::connect(&addr).map_err(|e| {
         format!(
             "failed to connect to the enclave to generate key pair: {:?}",

--- a/providers/nitro/nitro-helper/src/proxy.rs
+++ b/providers/nitro/nitro-helper/src/proxy.rs
@@ -8,7 +8,7 @@ use std::path::PathBuf;
 use std::thread;
 use std::time::Duration;
 use tracing::{error, info, trace};
-use vsock::{SockAddr, VsockListener};
+use vsock::{VsockAddr, VsockListener};
 
 /// Configuration parameters for port listening and remote destination
 pub struct Proxy {
@@ -29,7 +29,7 @@ impl Proxy {
     /// Returns the file descriptor for it or the appropriate error
     pub fn sock_listen(&self) -> Result<VsockListener, String> {
         info!("binding proxy to vsock port: {}", self.local_port);
-        let sockaddr = SockAddr::new_vsock(VSOCK_HOST_CID, self.local_port);
+        let sockaddr = VsockAddr::new(VSOCK_HOST_CID, self.local_port);
         let listener = VsockListener::bind(&sockaddr)
             .map_err(|_| format!("Could not bind to {:?}", sockaddr))?;
         info!("Bound to {:?}", sockaddr);

--- a/providers/nitro/nitro-helper/src/state.rs
+++ b/providers/nitro/nitro-helper/src/state.rs
@@ -12,7 +12,7 @@ use tmkms_light::chain::state::{consensus, StateError};
 use tmkms_light::error::{io_error_wrap, Error};
 use tmkms_light::utils::{read_u16_payload, write_u16_payload};
 use tracing::{debug, info, warn};
-use vsock::{SockAddr, VsockListener, VsockStream};
+use vsock::{VsockAddr, VsockListener, VsockStream};
 
 /// helps the enclave to load the state previously persisted on the host
 /// + to persist new states
@@ -46,7 +46,7 @@ impl StateSyncer {
             )),
         }?;
 
-        let sockaddr = SockAddr::new_vsock(VSOCK_HOST_CID, vsock_port);
+        let sockaddr = VsockAddr::new(VSOCK_HOST_CID, vsock_port);
         let vsock_listener = VsockListener::bind(&sockaddr)
             .map_err(|e| StateError::sync_error("vsock".into(), e))?;
 

--- a/providers/nitro/nitro-helper/src/tracing_layer.rs
+++ b/providers/nitro/nitro-helper/src/tracing_layer.rs
@@ -10,7 +10,7 @@ use tracing_core::{
     Field, Level, Metadata, Subscriber,
 };
 use tracing_subscriber::{layer::Context, registry::LookupSpan};
-use vsock::{SockAddr, VsockStream};
+use vsock::{VsockAddr, VsockStream};
 
 pub struct Layer {
     cid: u32,
@@ -28,7 +28,7 @@ impl Layer {
     }
 
     pub fn get_socket(&self) -> Result<VsockStream, String> {
-        let addr = SockAddr::new_vsock(self.cid, self.local_port);
+        let addr = VsockAddr::new(self.cid, self.local_port);
         VsockStream::connect(&addr).map_err(|e| {
             format!(
                 "failed to connect to the enclave server to push log: {:?}",


### PR DESCRIPTION
Solution: bumped the related crates in NE together
+ adjusted the API based on the breaking changes in vsock
