### PR TITLE
Problem: docker publish job fails due to an old toolchain

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -26,7 +26,7 @@ jobs:
           push: true
           file: Dockerfile.nitro
           build-args: |
-            RUST_TOOLCHAIN=1.56.1
+            RUST_TOOLCHAIN=1.62.1
           tags: |
             cryptocom/nitro-enclave-tmkms:latest
             cryptocom/nitro-enclave-tmkms:${{ steps.get_version.outputs.VERSION }}


### PR DESCRIPTION
Solution:
bumped toolchain to 1.62.1 (same as the other CI action)
The error was:
```
package `time v0.3.11` cannot be built because it requires rustc 1.57.0 or newer, while the currently active rustc version is 1.56.1
```
