### PR TITLE
Problem: sgx provider doesn't work in 0.4 (fixes #386)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+*August 9, 2022*
+
+A bug fix for the SGX provider and a few dependency upgrades.
+
+## v0.4.1
+### Bug Fixes
+* [387](https://github.com/crypto-com/tmkms-light/pull/387) SGX initialization and communication fix 
+
 *August 4, 2022*
 
 Many dependency upgrades.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2812,7 +2812,7 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tmkms-light"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "ed25519-dalek",
  "flex-error",
@@ -2828,7 +2828,7 @@ dependencies = [
 
 [[package]]
 name = "tmkms-light-sgx-app"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "aes",
  "aes-gcm-siv",
@@ -2854,7 +2854,7 @@ dependencies = [
 
 [[package]]
 name = "tmkms-light-sgx-runner"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "aesm-client",
  "base64",
@@ -2883,7 +2883,7 @@ dependencies = [
 
 [[package]]
 name = "tmkms-nitro-enclave"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "aws-ne-sys",
  "aws-nitro-enclaves-nsm-api",
@@ -2907,7 +2907,7 @@ dependencies = [
 
 [[package]]
 name = "tmkms-nitro-helper"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "aws-config",
  "aws-types",
@@ -2934,7 +2934,7 @@ dependencies = [
 
 [[package]]
 name = "tmkms-softsign"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "ed25519-dalek",
  "flex-error",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tmkms-light"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Tomas Tauber <2410580+tomtau@users.noreply.github.com>"]
 edition = "2021"
 

--- a/providers/nitro/nitro-enclave/Cargo.toml
+++ b/providers/nitro/nitro-enclave/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tmkms-nitro-enclave"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Tomas Tauber <2410580+tomtau@users.noreply.github.com>"]
 edition = "2021"
 

--- a/providers/nitro/nitro-helper/Cargo.toml
+++ b/providers/nitro/nitro-helper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tmkms-nitro-helper"
-version = "0.4.0"
+version = "0.4.1"
 authors = [ "Tomas Tauber <2410580+tomtau@users.noreply.github.com>" ]
 edition = "2021"
 

--- a/providers/sgx/sgx-app/Cargo.toml
+++ b/providers/sgx/sgx-app/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tmkms-light-sgx-app"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Tomas Tauber <2410580+tomtau@users.noreply.github.com>", "Linfeng Yuan <linfeng@crypto.com>"]
 edition = "2021"
 

--- a/providers/sgx/sgx-app/src/main.rs
+++ b/providers/sgx/sgx-app/src/main.rs
@@ -4,6 +4,10 @@ mod sgx_app;
 #[cfg(target_env = "sgx")]
 fn main() -> std::io::Result<()> {
     let mut args = std::env::args();
+    // enclave-runner had a breaking change that it started to pass the enclave path
+    if args.len() > 2 {
+        let _path = args.next();
+    }
     let command = args.next();
     let log_level = match args.next() {
         Some(s) if s == "verbose" => tracing::Level::DEBUG,

--- a/providers/sgx/sgx-runner/Cargo.toml
+++ b/providers/sgx/sgx-runner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tmkms-light-sgx-runner"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Tomas Tauber <2410580+tomtau@users.noreply.github.com>", "Linfeng Yuan <linfeng@crypto.com>"]
 edition = "2021"
 

--- a/providers/softsign/Cargo.toml
+++ b/providers/softsign/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tmkms-softsign"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Tomas Tauber <2410580+tomtau@users.noreply.github.com>"]
 edition = "2021"
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -63,10 +63,11 @@ pub fn read_u16_payload<S: Read>(stream: &mut S) -> Result<Vec<u8>, Error> {
         let mut total = 0;
 
         while let Ok(n) = stream.read(&mut state_raw[total..]) {
-            if n == 0 || n + total > l {
+            total += n;
+            // no more data to read
+            if n == 0 || total >= l {
                 break;
             }
-            total += n;
         }
 
         if total == 0 {


### PR DESCRIPTION
Solution: added handling of an extra arg due to the latest enclave runner
plus a fix for the payload reading
