### PR TITLE
Problem: unnecessary ignore in CI audit scan

### DIFF
--- a/.github/workflows/tmkms.yml
+++ b/.github/workflows/tmkms.yml
@@ -48,8 +48,6 @@ jobs:
       # RUSTSEC-2021-0127: serde_cbor used in upstream nsm-* crates
       # RUSTSEC-2020-0016,RUSTSEC-2021-0124: net2 used in mio from older tokio (used in sgx crates)
       # RUSTSEC-2022-0041: old cross-beam used in sgx runner crate
-      # RUSTSEC-2021-0139: https://github.com/crypto-com/tmkms-light/issues/414
-      # (may be possible to fix with a new version of tracing + upgrading clap)
       - run: >
           cargo audit --deny warnings
           --ignore RUSTSEC-2020-0071
@@ -59,7 +57,6 @@ jobs:
           --ignore RUSTSEC-2021-0127
           --ignore RUSTSEC-2019-0036
           --ignore RUSTSEC-2022-0041
-          --ignore RUSTSEC-2021-0139
   
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Solution: removed the unmaintained crate ignore, as it is no longer present in Cargo.lock
