### PR TITLE
Fix typo in documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ we ask you to refer to [security policy](SECURITY.md).
 There are several ways to identify an area where you can contribute to Tendermint KMS Light:
 
 * You can reach out by sending a message in the developer community communication channel, either with a specific contribution in mind or in general by saying "I want to help!".
-* Occassionally, some issues on Github may be labelled with `help wanted` or `good first issue` tags.
+* Occasionally, some issues on Github may be labelled with `help wanted` or `good first issue` tags.
 
 We use the variation of the "fork and pull" model where contributors push changes to their personal fork and create pull requests to bring those changes into the source repository.
 Changes in pull requests should satisfy "Patch Requirements" described in [The Collective Code Construction Contract (C4)](https://rfc.zeromq.org/spec:42/C4/#23-patch-requirements). The code should follow [Rust Style Guide](https://github.com/rust-lang/rfcs/tree/master/style-guide). Many of the code style rules are captured by [rustfmt](https://github.com/rust-lang/rustfmt), so please make sure to use `cargo fmt` before every commit (e.g. by configuring your editor to do it for you upon saving a file). The code comments should follow [Rust API Documentation guidelines and conventions](https://rust-lang-nursery.github.io/api-guidelines/documentation.html).


### PR DESCRIPTION
This PR fixes the typo in the documentation

# PR Checklist:

- [x] Have you read the [CONTRIBUTING.md](https://github.com/crypto-com/tmkms-light/blob/main/CONTRIBUTING.md)?
- [x] Does your PR follow the [C4 patch requirements](https://rfc.zeromq.org/spec:42/C4/#23-patch-requirements)?
- [x] Have you rebased your work on top of the latest main? 
- [x] Have you checked your code compiles? (`cargo build`)
- [x] Have you included tests for any non-trivial functionality?
- [x] Have you checked your code passes the unit tests? (`cargo test`)
- [x] Have you checked your code formatting is correct? (`cargo fmt -- --check --color=auto`)
- [x] Have you checked your basic code style is fine? (`cargo clippy`)
- [x] If you added any dependencies, have you checked they do not contain any known vulnerabilities? (`cargo audit`)
- [x] If your changes affect public APIs, does your PR follow the [C4 evolution of public contracts](https://rfc.zeromq.org/spec:42/C4/#26-evolution-of-public-contracts)?
- [x] If your code changes public APIs, have you incremented the crate version numbers and documented your changes in the [CHANGELOG.md](https://github.com/crypto-com/tmkms-light/blob/main/CHANGELOG.md)?
- [x] If you are contributing for the first time, please read the agreement in [CONTRIBUTING.md](https://github.com/crypto-com/tmkms-light/blob/main/CONTRIBUTING.md) now and add a comment to this pull request stating that your PR is in accordance with the [Developer's Certificate of Origin](https://github.com/crypto-com/tmkms-light/blob/main/CONTRIBUTING.md#developer-certificate-of-originn).